### PR TITLE
Adapt YAMLLint to allow fewer spaces before comments

### DIFF
--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -8,4 +8,6 @@ rules:
     spaces: 2
   line-length:
     max: 120
+  comments:
+    min-spaces-from-content: 1
 ...


### PR DESCRIPTION
build(pre-commit): Adapt YAMLLint to allow fewer spaces before comments